### PR TITLE
Add Content and Method type to OAuth2 defaults

### DIFF
--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2ContentType.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2ContentType.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * aws-custom-connector-sdk
+ * %%
+ * Copyright (C) 2021 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.appflow.custom.connector.model.connectorconfiguration.auth;
+
+/**
+ * OAuth2 Content type to use in the token request header. AppFlow uses this when making login requests.
+ * Default: URL_ENCODED
+ */
+public enum OAuth2ContentType {
+
+    /**
+     * Content Type is: "application/x-www-form-urlencoded"
+     */
+    URL_ENCODED,
+
+    /**
+     * Content Type is: "application/json"
+     */
+    APPLICATION_JSON
+}

--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2Defaults.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2Defaults.java
@@ -76,6 +76,22 @@ public interface OAuth2Defaults {
     List<OAuth2GrantType> oAuth2GrantTypesSupported();
 
     /**
+     * OAuth2 Content type to use in the token request header. Default: "application/x-www-form-urlencoded"
+     */
+    @Value.Default
+    default OAuth2ContentType oAuth2ContentType() {
+        return OAuth2ContentType.URL_ENCODED;
+    }
+
+    /**
+     * OAuth2 Http method to use for the token request. Default: "POST"
+     */
+    @Value.Default
+    default OAuth2MethodType oAuth2MethodType() {
+        return OAuth2MethodType.HTTP_POST;
+    }
+
+    /**
      * OAuth2 custom parameters needed by the connector.
      *
      *  In case of 3 legged OAuth2 AppFlow have clientId and scope defined as the default parameter for AUTH_URL to generate the Authorization code.

--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2MethodType.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2MethodType.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * aws-custom-connector-sdk
+ * %%
+ * Copyright (C) 2021 - 2022 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.appflow.custom.connector.model.connectorconfiguration.auth;
+
+/**
+ * OAuth2 Http method to use for the token request. AppFlow uses this when making login requests.
+ * Default: POST
+ */
+public enum OAuth2MethodType {
+
+    /**
+     * POST method type
+     */
+    HTTP_POST,
+
+    /**
+     * GET method type
+     */
+    HTTP_GET
+}


### PR DESCRIPTION
* Add two new fields to Oauth2Defaults: OAuth2ContentType and OAuth2MethodType
* Default these fields to URL_ENCODED and HTTP_POST for backwards compatibility


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
