### PR TITLE
Adding hasDestinationSupport bool in listConnectorEntities API

### DIFF
--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/metadata/Entity.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/metadata/Entity.java
@@ -48,6 +48,12 @@ public interface Entity {
     boolean hasNestedEntities();
 
     /**
+     * Specifies if the connector entity can be used in destination while creating flow
+     */
+    @Value.Default
+    default boolean hasDestinationSupport() { return true; }
+
+    /**
      * Label of the entity.
      */
     @Nullable


### PR DESCRIPTION
Adding one boolean in listConnectorEntities API as requested by persistent.

Testing :
Done backward compatible testing,
Different values of this bool from server , with/without metadata cache.

Issues
https://i.amazon.com/EC2ISV-1197

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
