### PR TITLE
Adding light weight saleforce api to validate credentials

### DIFF
--- a/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/ConnectorSettingKey.java
+++ b/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/ConnectorSettingKey.java
@@ -33,4 +33,5 @@ public final class ConnectorSettingKey {
 
     public static final String INSTANCE_URL = "instanceUrl";
     public static final String API_VERSION = "api_version";
+    public static final String IS_SANDBOX_ACCOUNT = "IsSandboxAccount";
 }

--- a/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/SalesforceConnectorConfiguration.java
+++ b/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/SalesforceConnectorConfiguration.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import static com.amazonaws.appflow.custom.connector.example.configuration.ConnectorSettingKey.API_VERSION;
 import static com.amazonaws.appflow.custom.connector.example.configuration.ConnectorSettingKey.INSTANCE_URL;
+import static com.amazonaws.appflow.custom.connector.example.configuration.ConnectorSettingKey.IS_SANDBOX_ACCOUNT;
 
 /**
  * Static Configuration for Salesforce connector.
@@ -60,16 +61,16 @@ public final class SalesforceConnectorConfiguration {
                 .scope(ConnectorRuntimeSettingScope.CONNECTOR_PROFILE)
                 .build();
 
-        ConnectorRuntimeSetting apiVersion = ImmutableConnectorRuntimeSetting.builder()
-                .key(API_VERSION)
-                .dataType(ConnectorRuntimeSettingDataType.String)
+        ConnectorRuntimeSetting isSandboxAccount = ImmutableConnectorRuntimeSetting.builder()
+                .key(IS_SANDBOX_ACCOUNT)
+                .dataType(ConnectorRuntimeSettingDataType.Boolean)
                 .required(true)
-                .label("Salesforce API version")
-                .description("Salesforce API version to use. (e.g. v54.0)")
+                .label("Type of salesforce account")
+                .description("Is Salesforce account a sandbox account")
                 .scope(ConnectorRuntimeSettingScope.CONNECTOR_PROFILE)
                 .build();
 
-        return Arrays.asList(instanceUrl, apiVersion);
+        return Arrays.asList(instanceUrl, isSandboxAccount);
     }
 
     public static List<ConnectorModes> getConnectorModes() {

--- a/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/handler/SalesforceConfigurationHandler.java
+++ b/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/handler/SalesforceConfigurationHandler.java
@@ -68,7 +68,6 @@ public class SalesforceConfigurationHandler extends AbstractSalesforceHandler im
     public ValidateCredentialsResponse validateCredentials(final ValidateCredentialsRequest request) {
         String requestUri = buildSalesforceUserInfoRequest(request);
         ConnectorContext connectorContext = ImmutableConnectorContext.builder()
-                .apiVersion(request.connectorRuntimeSettings().get(API_VERSION))
                 .credentials(request.credentials())
                 .connectorRuntimeSettings(request.connectorRuntimeSettings())
                 .build();

--- a/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/handler/SalesforceConfigurationHandler.java
+++ b/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/handler/SalesforceConfigurationHandler.java
@@ -24,8 +24,11 @@
 
 package com.amazonaws.appflow.custom.connector.example.handler;
 
+import com.amazonaws.appflow.custom.connector.example.SalesforceResponse;
 import com.amazonaws.appflow.custom.connector.example.configuration.SalesforceConnectorConfiguration;
 import com.amazonaws.appflow.custom.connector.handlers.ConfigurationHandler;
+import com.amazonaws.appflow.custom.connector.model.ConnectorContext;
+import com.amazonaws.appflow.custom.connector.model.ErrorDetails;
 import com.amazonaws.appflow.custom.connector.model.ImmutableConnectorContext;
 import com.amazonaws.appflow.custom.connector.model.connectorconfiguration.DescribeConnectorConfigurationRequest;
 import com.amazonaws.appflow.custom.connector.model.connectorconfiguration.DescribeConnectorConfigurationResponse;
@@ -33,21 +36,24 @@ import com.amazonaws.appflow.custom.connector.model.connectorconfiguration.Immut
 import com.amazonaws.appflow.custom.connector.model.credentials.ImmutableValidateCredentialsResponse;
 import com.amazonaws.appflow.custom.connector.model.credentials.ValidateCredentialsRequest;
 import com.amazonaws.appflow.custom.connector.model.credentials.ValidateCredentialsResponse;
-import com.amazonaws.appflow.custom.connector.model.metadata.ImmutableListEntitiesRequest;
-import com.amazonaws.appflow.custom.connector.model.metadata.ListEntitiesRequest;
-import com.amazonaws.appflow.custom.connector.model.metadata.ListEntitiesResponse;
 import com.amazonaws.appflow.custom.connector.model.settings.ImmutableValidateConnectorRuntimeSettingsResponse;
 import com.amazonaws.appflow.custom.connector.model.settings.ValidateConnectorRuntimeSettingsRequest;
 import com.amazonaws.appflow.custom.connector.model.settings.ValidateConnectorRuntimeSettingsResponse;
 
+import java.util.Map;
 import java.util.Objects;
 
 import static com.amazonaws.appflow.custom.connector.example.configuration.ConnectorSettingKey.API_VERSION;
+import static com.amazonaws.appflow.custom.connector.example.configuration.ConnectorSettingKey.IS_SANDBOX_ACCOUNT;
 
 /**
  * Salesforce Configuration handler.
  */
-public class SalesforceConfigurationHandler implements ConfigurationHandler {
+public class SalesforceConfigurationHandler extends AbstractSalesforceHandler implements ConfigurationHandler {
+
+    public static final String SALESFORCE_USERINFO_URL_FORMAT = "https://login.salesforce.com/services/oauth2/userinfo";
+    public static final String SALESFORCE_USERINFO_SANDBOX_URL_FORMAT = "https://test.salesforce.com/services/oauth2/userinfo";
+    public static final String TRUE = "TRUE";
 
     private static final String CONNECTOR_OWNER = "SampleConnector";
     private static final String CONNECTOR_NAME = "SampleSalesforceConnector";
@@ -60,18 +66,19 @@ public class SalesforceConfigurationHandler implements ConfigurationHandler {
 
     @Override
     public ValidateCredentialsResponse validateCredentials(final ValidateCredentialsRequest request) {
-        final ListEntitiesRequest listEntitiesRequest = ImmutableListEntitiesRequest.builder()
-                .connectorContext(ImmutableConnectorContext.builder()
-                        .apiVersion((String) request.connectorRuntimeSettings().get(API_VERSION))
-                        .credentials(request.credentials())
-                        .connectorRuntimeSettings(request.connectorRuntimeSettings())
-                        .build())
+        String requestUri = buildSalesforceUserInfoRequest(request);
+        ConnectorContext connectorContext = ImmutableConnectorContext.builder()
+                .apiVersion(request.connectorRuntimeSettings().get(API_VERSION))
+                .credentials(request.credentials())
+                .connectorRuntimeSettings(request.connectorRuntimeSettings())
                 .build();
-        final ListEntitiesResponse response = new SalesforceMetadataHandler().listEntities(listEntitiesRequest);
-        if (Objects.nonNull(response.errorDetails())) {
+
+        final SalesforceResponse response = getSalesforceClient(connectorContext).restGet(requestUri);
+        ErrorDetails errorDetails = checkForErrorsInSalesforceResponse(response);
+        if (Objects.nonNull(errorDetails)) {
             return ImmutableValidateCredentialsResponse.builder()
                     .isSuccess(false)
-                    .errorDetails(response.errorDetails())
+                    .errorDetails(errorDetails)
                     .build();
         } else {
             return ImmutableValidateCredentialsResponse.builder().isSuccess(true).build();
@@ -91,5 +98,17 @@ public class SalesforceConfigurationHandler implements ConfigurationHandler {
                 .supportedApiVersions(SalesforceConnectorConfiguration.getSupportedApiVersions())
                 .supportedWriteOperations(SalesforceConnectorConfiguration.supportedWriteOperations())
                 .build();
+    }
+
+    private String buildSalesforceUserInfoRequest(final ValidateCredentialsRequest request) {
+        Map<String, String> connectorRuntimeSettings = request.connectorRuntimeSettings();
+        if (Objects.isNull(connectorRuntimeSettings)) {
+            return SALESFORCE_USERINFO_URL_FORMAT;
+        }
+        if (connectorRuntimeSettings.containsKey(IS_SANDBOX_ACCOUNT) &&
+                TRUE.equalsIgnoreCase(connectorRuntimeSettings.get(IS_SANDBOX_ACCOUNT))) {
+            return SALESFORCE_USERINFO_SANDBOX_URL_FORMAT;
+        }
+        return SALESFORCE_USERINFO_URL_FORMAT;
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding light weight saleforce api to validate credentials. instead of calling list connector entities we have used user info api.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
