### PR TITLE
Basic auth support for OAuth2

### DIFF
--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2Defaults.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/auth/OAuth2Defaults.java
@@ -99,4 +99,10 @@ public interface OAuth2Defaults {
      */
     @Nullable
     List<OAuth2CustomParameter> oauth2CustomProperties();
+
+    /**
+     * Specifies if clientId and clientSecret should be added to basic auth header
+     */
+    @Value.Default
+    default boolean addBasicAuthHeader() { return false; };
 }


### PR DESCRIPTION
This is regarding issue. https://issues.amazon.com/issues/EC2ISV-1659

We need to add Base64 encoded Basic Auth header while making OAuth2 request.
Even if connector doesnt provide refreshtoken, CVS should able to return new access token. Testing : Tested with domo connector deployed with local stack with CP/DP/CVS about createConnectorProfile, flow scenario.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
