### PR TITLE
Adding test URL's for sandbox account

### DIFF
--- a/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/SalesforceConnectorConfiguration.java
+++ b/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/SalesforceConnectorConfiguration.java
@@ -35,6 +35,7 @@ import com.amazonaws.appflow.custom.connector.model.connectorconfiguration.auth.
 import com.amazonaws.appflow.custom.connector.model.connectorconfiguration.auth.ImmutableAuthenticationConfig;
 import com.amazonaws.appflow.custom.connector.model.settings.ImmutableConnectorRuntimeSetting;
 import com.amazonaws.appflow.custom.connector.model.write.WriteOperationType;
+import com.google.common.collect.ImmutableList;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -86,8 +87,10 @@ public final class SalesforceConnectorConfiguration {
 
     private static OAuth2Defaults getOAuth2Defaults() {
         return ImmutableOAuth2Defaults.builder()
-                .authURL(Collections.singletonList("https://login.salesforce.com/services/oauth2/authorize"))
-                .tokenURL(Collections.singletonList("https://login.salesforce.com/services/oauth2/token"))
+                .authURL(ImmutableList.of("https://login.salesforce.com/services/oauth2/authorize",
+                        "https://test.salesforce.com/services/oauth2/authorize"))
+                .tokenURL(ImmutableList.of("https://login.salesforce.com/services/oauth2/token",
+                        "https://test.salesforce.com/services/oauth2/token"))
                 .oAuthScopes(Arrays.asList("api", "refresh_token"))
                 .addOAuth2GrantTypesSupported(OAuth2GrantType.AUTHORIZATION_CODE)
                 .build();


### PR DESCRIPTION
*Description of changes:*
Adding Sandbox URL's in oauth2 defaults and removing connector context for config handler. Tested the changes by deploying the lambda locally and testing the flow execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
