### PR TITLE
Data transfer type

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added support for `LIMIT` in the query filter expression.
 - Added a JSON validator to validate that objects match the SDK format.
 - Added `Url` type in the ConnectorRuntimeSettingDataType.
+- Added `DataTransferType` ENUM and added supportedDataTransferTypes in DescribeConnectorConfigurationResponse
 
 ## [1.0.8] - 2022-12-21
 ### Added

--- a/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/SalesforceConnectorConfiguration.java
+++ b/custom-connector-example/src/main/java/com/amazonaws/appflow/custom/connector/example/configuration/SalesforceConnectorConfiguration.java
@@ -54,7 +54,7 @@ public final class SalesforceConnectorConfiguration {
     public static List<ConnectorRuntimeSetting> getConnectorRuntimeSettings() {
         ConnectorRuntimeSetting instanceUrl = ImmutableConnectorRuntimeSetting.builder()
                 .key(INSTANCE_URL)
-                .dataType(ConnectorRuntimeSettingDataType.String)
+                .dataType(ConnectorRuntimeSettingDataType.Url)
                 .required(true)
                 .label("Salesforce Instance URL")
                 .description("URL of the instance where user wants to run the operations.")

--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/DataTransferType.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/DataTransferType.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * aws-custom-connector-sdk
+ * %%
+ * Copyright (C) 2021 - 2023 Amazon Web Services
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.amazonaws.appflow.custom.connector.model.connectorconfiguration;
+
+/**
+ * Enum class representing the types of data transfers.
+ */
+public enum DataTransferType {
+    /**
+     * Represents data transfer in the form of records. This type is used when data transfer involves structured records.
+     */
+    RECORD,
+    /**
+     * Represents data transfer in the form of files. This type is used when data transfer involves files or binary data.
+     */
+    FILE
+}

--- a/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/DescribeConnectorConfigurationResponse.java
+++ b/custom-connector-sdk/src/main/java/com/amazonaws/appflow/custom/connector/model/connectorconfiguration/DescribeConnectorConfigurationResponse.java
@@ -132,4 +132,15 @@ public interface DescribeConnectorConfigurationResponse {
      */
     @Nullable
     ErrorDetails errorDetails();
+
+    /**
+     * Specifies a list of DataTransferType options the connector can support.
+     * Connector that support RECORD as a source is compatible with connectors that support either RECORD or FILE as destinations.
+     * Connector that support FILE as a source is only compatible with connectors that support FILE transfer as destinations.
+     */
+    @Value.Default
+    @Nullable
+    default List<DataTransferType> supportedDataTransferTypes() {
+        return Arrays.asList(DataTransferType.RECORD);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
    Added `DataTransferType` ENUM and added supportedDataTransferTypes in DescribeConnectorConfigurationResponse
    Modify INSTANCE_URL in the example connector to Url type


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
